### PR TITLE
Fix #5 add delete confirm modal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ stages:
 - export METADATA_CPCONFIG="$PWD/travis/server.conf"
 - source ~/virtualenv/python3.6/bin/activate
 - pip install --upgrade setuptools wheel pip
-- pip install pacifica-metadata
+- pip install pacifica-metadata uwsgi
 - pacifica-metadata-cmd dbsync
-- python -m pacifica.metadata & echo $! > metadata.pid
+- uwsgi --http-socket :8121 --module pacifica.metadata.wsgi & echo $! > metadata.pid
 - |
   MAX_TRIES=60
   HTTP_CODE=$(curl -sL -w "%{http_code}\\n" localhost:8121/keys -o /dev/null || true)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ You don’t have to ever use `eject`. The curated feature set is suitable for sm
 
 ## End-to-End Testing
 
+This documentation is designed for developers to build and test the
+Pacifica Metadata Management tool. The processes for building a React
+and NodeJS site must be followed prior to following the instructions
+below.
+
 ### Development Environment Requirements
 
 You should have the following available installed and available in your path.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13115,6 +13115,11 @@
         }
       }
     },
+    "react-confirm-alert": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-confirm-alert/-/react-confirm-alert-2.4.1.tgz",
+      "integrity": "sha512-Sc2N1paCTCS5HWEAhik2IQa9/vwSQLAoCT5uccjPH/VyTaBAkRPZPx9sUqFTy3q5VnnGwCPsoz7fnw54x79d/w=="
+    },
     "react-dev-utils": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-9.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "classnames": "^2.2.6",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
+    "react-confirm-alert": "^2.4.1",
     "react-dom": "^16.8.6",
     "react-scripts": "3.0.0",
     "react-table": "^6.10.0"

--- a/src/App.js
+++ b/src/App.js
@@ -160,7 +160,7 @@ class App extends React.Component {
             {Object.entries(objectList).sort().map((items, index) => {
               return (
                 <ListItem
-                  id={`listitem-${items[0].replace('_', '-')}`}
+                  id={`listitem-${items[0].replace(/_/g, '-')}`}
                   button
                   key={items[0]}
                   onClick={() => {

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -260,7 +260,7 @@ class SimpleModal extends React.Component {
         <IconButton
           color="inherit"
           aria-label={`Open ${this.props.title}`}
-          id={`modal-button-${this.props.title.toLowerCase()}`}
+          id={`modal-button-${this.props.title.replace(/ /g, '-').toLowerCase()}`}
           onClick={this.handleOpen}
         >
           {icon()}

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -67,7 +67,7 @@ class SimpleModal extends React.Component {
                         label={key}
                         type="datetime-local"
                         defaultValue={defaults[key]}
-                        id={`modal-input-${key}`}
+                        id={`modal-input-${key.replace(/_/g, '-')}`}
                         onChange={event => {
                           this.updateFormInput(key, event.target.value)
                         }}
@@ -82,7 +82,7 @@ class SimpleModal extends React.Component {
                     <TextField
                       InputLabelProps={{ shrink: true }}
                       label={key}
-                      id={`modal-input-${key}`}
+                      id={`modal-input-${key.replace(/_/g, '-')}`}
                       type="date-local"
                       defaultValue={defaults[key]}
                       onChange={event => {
@@ -99,11 +99,11 @@ class SimpleModal extends React.Component {
                   actualKey = `_${key}`
                 }
                 fieldDef = (
-                  <Grid item xs={12} sm={6} key={key}>
+                  <Grid item xs={12} sm={6} key={key.replace(/_/g, '-')}>
                     <TextField
                       InputLabelProps={{ shrink: true }}
                       label={key}
-                      id={`modal-input-${key}`}
+                      id={`modal-input-${key.replace(/_/g, '-')}`}
                       defaultValue={defaults[actualKey]}
                       multiline={fieldTypes[key] === 'TEXT'}
                       onChange={event => {
@@ -119,7 +119,7 @@ class SimpleModal extends React.Component {
                     <TextField
                       InputLabelProps={{ shrink: true }}
                       label={key}
-                      id={`modal-input-${key}`}
+                      id={`modal-input-${key.replace(/_/g, '-')}`}
                       defaultValue={defaults[key]}
                       onChange={event => {
                         this.updateFormInput(key, event.target.value)
@@ -135,7 +135,7 @@ class SimpleModal extends React.Component {
                     <TextField
                       type="number"
                       label={key}
-                      id={`modal-input-${key}`}
+                      id={`modal-input-${key.replace(/_/g, '-')}`}
                       defaultValue={defaults[key]}
                       InputLabelProps={{ shrink: true }}
                       onChange={event => {
@@ -151,7 +151,7 @@ class SimpleModal extends React.Component {
                     <Typography>{key}</Typography>
                     <Checkbox
                       label={key}
-                      id={`modal-input-${key}`}
+                      id={`modal-input-${key.replace(/_/g, '-')}`}
                       value={key}
                       defaultChecked={this.state.formData[key]}
                       onChange={event => {
@@ -166,7 +166,7 @@ class SimpleModal extends React.Component {
                   <Grid item xs={12} sm={6} key={key}>
                     <TextField
                       label={key}
-                      id={`modal-input-${key}`}
+                      id={`modal-input-${key.replace(/_/g, '-')}`}
                       defaultValue={defaults[`_${key}`]}
                       InputLabelProps={{ shrink: true }}
                       onChange={event => {

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -67,6 +67,7 @@ class SimpleModal extends React.Component {
                         label={key}
                         type="datetime-local"
                         defaultValue={defaults[key]}
+                        id={`modal-input-${key}`}
                         onChange={event => {
                           this.updateFormInput(key, event.target.value)
                         }}
@@ -81,6 +82,7 @@ class SimpleModal extends React.Component {
                     <TextField
                       InputLabelProps={{ shrink: true }}
                       label={key}
+                      id={`modal-input-${key}`}
                       type="date-local"
                       defaultValue={defaults[key]}
                       onChange={event => {
@@ -101,6 +103,7 @@ class SimpleModal extends React.Component {
                     <TextField
                       InputLabelProps={{ shrink: true }}
                       label={key}
+                      id={`modal-input-${key}`}
                       defaultValue={defaults[actualKey]}
                       multiline={fieldTypes[key] === 'TEXT'}
                       onChange={event => {
@@ -116,6 +119,7 @@ class SimpleModal extends React.Component {
                     <TextField
                       InputLabelProps={{ shrink: true }}
                       label={key}
+                      id={`modal-input-${key}`}
                       defaultValue={defaults[key]}
                       onChange={event => {
                         this.updateFormInput(key, event.target.value)
@@ -131,6 +135,7 @@ class SimpleModal extends React.Component {
                     <TextField
                       type="number"
                       label={key}
+                      id={`modal-input-${key}`}
                       defaultValue={defaults[key]}
                       InputLabelProps={{ shrink: true }}
                       onChange={event => {
@@ -146,6 +151,7 @@ class SimpleModal extends React.Component {
                     <Typography>{key}</Typography>
                     <Checkbox
                       label={key}
+                      id={`modal-input-${key}`}
                       value={key}
                       defaultChecked={this.state.formData[key]}
                       onChange={event => {
@@ -160,6 +166,7 @@ class SimpleModal extends React.Component {
                   <Grid item xs={12} sm={6} key={key}>
                     <TextField
                       label={key}
+                      id={`modal-input-${key}`}
                       defaultValue={defaults[`_${key}`]}
                       InputLabelProps={{ shrink: true }}
                       onChange={event => {
@@ -252,7 +259,8 @@ class SimpleModal extends React.Component {
       <div>
         <IconButton
           color="inherit"
-          aria-label="Open create"
+          aria-label={`Open ${this.props.title}`}
+          id={`modal-button-${this.props.title.toLowerCase()}`}
           onClick={this.handleOpen}
         >
           {icon()}
@@ -270,10 +278,10 @@ class SimpleModal extends React.Component {
             <form>
               <FormControl component="fieldset">
                 {this.state.formInputs}
-                <IconButton onClick={this.handleClose} key="close-button">
+                <IconButton onClick={this.handleClose} id="modal-button-close" key="close-button">
                   <CloseIcon />
                 </IconButton>
-                <IconButton onClick={this.handleSave} key="save-button">
+                <IconButton onClick={this.handleSave} id="modal-button-save" key="save-button">
                   <SaveIcon />
                 </IconButton>
               </FormControl>

--- a/src/PacificaAPI.js
+++ b/src/PacificaAPI.js
@@ -68,7 +68,7 @@ export const convertColumns = (
             <Grid container spacing={8}>
               <Grid item xs={8} sm={4} key="edit-modal">
                 <SimpleModal
-                  title="Edit"
+                  title={`Edit Row ${row.row._index}`}
                   MDUrl={MDUrl}
                   object={object}
                   defaults={row.row}
@@ -79,7 +79,8 @@ export const convertColumns = (
               <Grid item xs={8} sm={4} key="delete-button">
                 <IconButton
                   color="inherit"
-                  aria-label="Delete item"
+                  aria-label={`Delete Row ${row.row._index}`}
+                  id={`modal-button-delete-row-${row.row._index}`}
                   onClick={() => {
                     confirmAlert({
                       title: 'Confirm to Delete',

--- a/src/PacificaAPI.js
+++ b/src/PacificaAPI.js
@@ -5,6 +5,8 @@ import EditIcon from '@material-ui/icons/Edit'
 import DeleteIcon from '@material-ui/icons/Delete'
 import IconButton from '@material-ui/core/IconButton'
 import Checkbox from '@material-ui/core/Checkbox'
+import { confirmAlert } from 'react-confirm-alert'; // Import
+import 'react-confirm-alert/src/react-confirm-alert.css'; // Import css
 import DateTimeDisplay from './DateTime'
 import SimpleModal from './Modal'
 
@@ -79,19 +81,31 @@ export const convertColumns = (
                   color="inherit"
                   aria-label="Delete item"
                   onClick={() => {
-                    Axios.delete(`${MDUrl}/${object}`, {
-                      params: deleteArgs
+                    confirmAlert({
+                      title: 'Confirm to Delete',
+                      message: `Are you sure you want to delete? ${JSON.stringify(deleteArgs)}`,
+                      buttons: [
+                        {
+                          label: 'Yes',
+                          onClick: () => {
+                            Axios.delete(`${MDUrl}/${object}`, {
+                              params: deleteArgs
+                            }).then(res => {
+                              // eslint-disable-next-line no-console
+                              console.log(res)
+                              updateFunc()
+                            }).catch(res => {
+                              // eslint-disable-next-line no-console
+                              console.log(JSON.stringify(res, null, 2))
+                              alert(res.response.data.traceback)
+                            })
+                          }
+                        }, {
+                          label: 'No',
+                          onClick: () => null
+                        }
+                      ]
                     })
-                      .then(res => {
-                        // eslint-disable-next-line no-console
-                        console.log(res)
-                        updateFunc()
-                      })
-                      .catch(res => {
-                        // eslint-disable-next-line no-console
-                        console.log(JSON.stringify(res, null, 2))
-                        alert(res.response.data.traceback)
-                      })
                   }}
                 >
                   <DeleteIcon />

--- a/tests/create_delete.test.js
+++ b/tests/create_delete.test.js
@@ -14,9 +14,15 @@ module.exports = {
         browser.setValue('input[id=modal-input-display-name]', 'Some New Key')
         browser.click('button[id=modal-button-save]')
         browser.click('button[id=modal-button-close]')
-        browser.pause(200)
+        browser.waitForElementPresent('button[id=modal-delete-row-0]')
         browser.assert.containsText('#root', 'Some New Key')
         browser.assert.containsText('#root', 'some_new_key')
+        browser.click('button[id=modal-delete-row-0]')
+        browser.waitForElementPresent('div[id=react-confirm-alert]')
+        browser.assert.containsText('#react-confirm-alert', '{"force":"True","_id":1}')
+        browser.click('div#react-confirm-alert button') // This should be the yes button
+        browser.assert.not.containsText('#root', 'Some New Key')
+        browser.assert.not.containsText('#root', 'some_new_key')
         browser.end()
     }
 }

--- a/tests/create_delete.test.js
+++ b/tests/create_delete.test.js
@@ -1,0 +1,22 @@
+module.exports = {
+    'Create and Delete a Key': function (browser) {
+        browser.url('http://localhost:8080')
+        browser.waitForElementPresent('button[id=header-open-drawer]')
+        browser.click('button[id=header-open-drawer]')
+        browser.waitForElementPresent('div[id=listitem-keys]')
+        browser.click('div[id=listitem-keys]')
+        browser.waitForElementPresent('button[id=drawer-close-drawer]')
+        browser.click('button[id=drawer-close-drawer]')
+        browser.waitForElementPresent('button[id=modal-button-create]')
+        browser.click('button[id=modal-button-create]')
+        browser.waitForElementPresent('input[id=modal-input-key]')
+        browser.setValue('input[id=modal-input-key]', 'some_new_key')
+        browser.setValue('input[id=modal-input-display_name]', 'Some New Key')
+        browser.click('button[id=modal-button-save]')
+        browser.click('button[id=modal-button-close]')
+        browser.pause(200)
+        browser.assert.containsText('#root', 'Some New Key')
+        browser.assert.containsText('#root', 'some_new_key')
+        browser.end()
+    }
+}

--- a/tests/create_delete.test.js
+++ b/tests/create_delete.test.js
@@ -21,8 +21,8 @@ module.exports = {
         browser.waitForElementPresent('div[id=react-confirm-alert]')
         browser.assert.containsText('#react-confirm-alert', '{"force":"True","_id":1}')
         browser.click('div#react-confirm-alert button') // This should be the yes button
-        browser.assert.not.containsText('#root', 'Some New Key')
-        browser.assert.not.containsText('#root', 'some_new_key')
+        browser.expect.element('#root').text.to.not.contain('Some New Key');
+        browser.expect.element('#root').text.to.not.contain('some_new_key');
         browser.end()
     }
 }

--- a/tests/create_delete.test.js
+++ b/tests/create_delete.test.js
@@ -11,7 +11,7 @@ module.exports = {
         browser.click('button[id=modal-button-create]')
         browser.waitForElementPresent('input[id=modal-input-key]')
         browser.setValue('input[id=modal-input-key]', 'some_new_key')
-        browser.setValue('input[id=modal-input-display_name]', 'Some New Key')
+        browser.setValue('input[id=modal-input-display-name]', 'Some New Key')
         browser.click('button[id=modal-button-save]')
         browser.click('button[id=modal-button-close]')
         browser.pause(200)

--- a/tests/create_delete.test.js
+++ b/tests/create_delete.test.js
@@ -1,26 +1,35 @@
 module.exports = {
     'Create and Delete a Key': function (browser) {
         browser.url('http://localhost:8080')
+        browser.pause(100)
         browser.waitForElementPresent('button[id=header-open-drawer]')
         browser.click('button[id=header-open-drawer]')
+        browser.pause(100)        
         browser.waitForElementPresent('div[id=listitem-keys]')
         browser.click('div[id=listitem-keys]')
+        browser.pause(100)
         browser.waitForElementPresent('button[id=drawer-close-drawer]')
         browser.click('button[id=drawer-close-drawer]')
+        browser.pause(100)
         browser.waitForElementPresent('button[id=modal-button-create]')
         browser.click('button[id=modal-button-create]')
-        browser.waitForElementPresent('input[id=modal-input-key]')
+        browser.pause(100)
+        browser.waitForElementPresent('input[id=modal-input-id]')
+        browser.setValue('input[id=modal-input-id]', '1')
         browser.setValue('input[id=modal-input-key]', 'some_new_key')
         browser.setValue('input[id=modal-input-display-name]', 'Some New Key')
         browser.click('button[id=modal-button-save]')
+        browser.pause(100)
         browser.click('button[id=modal-button-close]')
-        browser.waitForElementPresent('button[id=modal-delete-row-0]')
-        browser.assert.containsText('#root', 'Some New Key')
-        browser.assert.containsText('#root', 'some_new_key')
-        browser.click('button[id=modal-delete-row-0]')
+        browser.pause(200)
+        browser.expect.element('#root').text.to.contain('Some New Key');
+        browser.expect.element('#root').text.to.contain('some_new_key');
+        browser.click('button[id=modal-button-delete-row-0]')
+        browser.pause(100)
         browser.waitForElementPresent('div[id=react-confirm-alert]')
-        browser.assert.containsText('#react-confirm-alert', '{"force":"True","_id":1}')
+        browser.expect.element('#react-confirm-alert').text.to.contain('{"force":"True","_id":1}');
         browser.click('div#react-confirm-alert button') // This should be the yes button
+        browser.pause(100)
         browser.expect.element('#root').text.to.not.contain('Some New Key');
         browser.expect.element('#root').text.to.not.contain('some_new_key');
         browser.end()

--- a/tests/read.test.js
+++ b/tests/read.test.js
@@ -76,9 +76,9 @@ module.exports = {
     for (let i = 0; i < objList.length; i++) {
       let obj = dataExamples[objList[i]]
       browser.pause(200)
-      browser.waitForElementPresent(`div[id=listitem-${objList[i].replace('_', '-')}]`)
-      browser.click(`div[id=listitem-${objList[i].replace('_', '-')}`)
-      browser.pause(200)
+      browser.waitForElementPresent(`div[id=listitem-${objList[i].replace(/_/g, '-')}]`)
+      browser.click(`div[id=listitem-${objList[i].replace(/_/g, '-')}]`)
+      browser.pause(300)
       browser.assert.containsText('#root', obj[dataColumns[objList[i]]])
     }
     browser.waitForElementPresent('button[id=drawer-close-drawer]')


### PR DESCRIPTION
### Description

This adds a delete confirm modal to verify before deleting that
the user really wants to.

NOTE: this uses a react component that isn't part of MaterialUI
but I think we could make it MaterialUI if we wanted.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

Fix #5 
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
