### PR TITLE
Fix #18 Add filter text testing

### DIFF
--- a/src/PacificaAPI.js
+++ b/src/PacificaAPI.js
@@ -14,14 +14,14 @@ export const getObjectList = MDUrl => {
   return Axios.get(`${MDUrl}/objectinfo/list`)
 }
 
-export const filteredWhereArgs = (fieldList, filtered) => {
+export const filteredWhereArgs = (fieldTypes, filtered) => {
   let whereArgs = {}
   for (let i = 0; i < filtered.length; i++) {
     if (filtered[i].id === '_id') {
       whereArgs._id = filtered[i].value
       return whereArgs
     }
-    switch (fieldList[filtered[i].id]) {
+    switch (fieldTypes[filtered[i].id]) {
       case 'TEXT':
       case 'VARCHAR':
         filtered[i].disableLike = false
@@ -154,7 +154,7 @@ export const getData = (
 ) => {
   return new Promise((resolve, reject) => {
     Axios.get(`${MDUrl}/objectinfo/${object}`).then(res => {
-      let whereArgs = filteredWhereArgs(res.data.field_list, filtered)
+      let whereArgs = filteredWhereArgs(res.data.field_types, filtered)
       Axios.get(`${MDUrl}/objectinfo/${object}`, { params: whereArgs }).then(res => {
         let recordCount = res.data.record_count
         let columns = convertColumns(

--- a/tests/issue_18.test.js
+++ b/tests/issue_18.test.js
@@ -1,0 +1,32 @@
+module.exports = {
+    'Create a User Group entry': function (browser) {
+        // Open up the browser to the website
+        browser.url('http://localhost:8080')
+        browser.pause(100)
+        // Wait for the open drawer icon to show up
+        browser.waitForElementPresent('button[id=header-open-drawer]')
+        // Open the drawer
+        browser.click('button[id=header-open-drawer]')
+        browser.pause(100)
+        // Wait for Relationships to show up in the drawer
+        browser.waitForElementPresent('div[id=listitem-relationships]')
+        // Click on the Relationships text
+        browser.click('div[id=listitem-relationships]')
+        browser.pause(100)
+        // Wait for the close drawer icon to show up
+        browser.waitForElementPresent('button[id=drawer-close-drawer]')
+        // Close the drawer
+        browser.click('button[id=drawer-close-drawer]')
+        browser.pause(100)
+        // Wait for the `name` filter field to show up
+        browser.waitForElementPresent('#root > div > main > div:nth-child(2) > div.ReactTable > div.rt-table > div.rt-thead.-filters > div > div:nth-child(6) > input[type=text]')
+        // Enter a short string in the filter field for `name`
+        browser.setValue('#root > div > main > div:nth-child(2) > div.ReactTable > div.rt-table > div.rt-thead.-filters > div > div:nth-child(6) > input[type=text]', 'mem')
+        browser.pause(200)
+        // Verify the member_of relationship is in the table
+        browser.expect.element('#root').text.to.contain('member_of')
+        browser.expect.element('#root').text.to.not.contain('custodian')
+        browser.expect.element('#root').text.to.not.contain('authorized_releaser')
+        browser.end()
+    }
+}


### PR DESCRIPTION
### Description

This adds a test to filter text fields properly. Any other field
types do not filter with like operators. This is a function of the
Pacifica Metadata API.

Signed-off-by: David Brown <dmlb2000@gmail.com>


### Issues Resolved

Fix #18 
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
